### PR TITLE
ci: Print missing migrations in CI

### DIFF
--- a/docker/init-test.sh
+++ b/docker/init-test.sh
@@ -1,8 +1,11 @@
 #!/bin/sh -e
 
+set -x
+
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
 python /app/manage.py collectstatic --no-input
 pytest --cov --cov-report=xml
 if [ -d /coverage ]; then cp .coverage coverage.xml /coverage/; fi
-python /app/manage.py makemigrations --check --dry-run --no-input
+python /app/manage.py makemigrations --dry-run --no-input
+python /app/manage.py makemigrations --check --no-input


### PR DESCRIPTION
When [the CI checks for missing migrations](https://github.com/ietf-tools/www/blob/d963ff91c2a619f8a12f6d41ddc6e8a03a0aedc4/docker/init-test.sh#L8), it doesn't print any output, so it's difficult to figure out what failed (e.g. [this failure](https://github.com/ietf-tools/www/actions/runs/8423748999/job/23066090470#step:6:275)). With this patch, [the output](https://github.com/ietf-tools/www/actions/runs/8434427323/job/23097626477#step:6:281) is actually helpful.

https://stackoverflow.com/a/77259833/51801