### PR TITLE
fix: BlogPage may only be created under BlogIndexPage

### DIFF
--- a/ietf/blog/models.py
+++ b/ietf/blog/models.py
@@ -157,6 +157,11 @@ class BlogPage(Page, BibliographyMixin, PromoteMixin):
     )
     CONTENT_FIELD_MAP = {"body": "prepared_body"}
 
+    parent_page_types = [
+        "blog.BlogIndexPage",
+    ]
+    subpage_types = []
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filter_topic = None


### PR DESCRIPTION
Fix https://github.com/ietf-tools/www/issues/337.
Fix https://github.com/ietf-tools/www/issues/271.

The blog page template depends on its parent page being a `BlogPageIndex`, so it crashes if its parent is anything else.