### PR TITLE
fix: Links in megamenu

### DIFF
--- a/ietf/utils/context_processors.py
+++ b/ietf/utils/context_processors.py
@@ -47,7 +47,7 @@ class MainMenu:
         main_section_links = [
             {
                 "title": page.title,
-                "url": item.page.get_url(current_site=self.site),
+                "url": page.get_url(current_site=self.site),
             }
             for page in item.page.get_children().live().in_menu()
         ]


### PR DESCRIPTION
From @ghwood:

> I think I have found a bug in the [new main menu structure](https://github.com/ietf-tools/www/issues/326) where the auto-generated elements of a megamenu main menu item do not actually link to the specific pages intended. For example, at https://wwwstaging.ietf.org/ see the links under the “Process” heading such as “Internet standards process”. The manually-linked elements (such as the “Appeals” element under the “Standards process” heading) do work as expected.

This is also fixed in https://github.com/ietf-tools/www/pull/395, but it might be worth merging the fix before that PR, so that the megamenu can be deployed.