### PR TITLE
chore: Only offer LTS version upgrades

### DIFF
--- a/ietf/settings/base.py
+++ b/ietf/settings/base.py
@@ -254,3 +254,5 @@ if _cf_purge_bearer_token and _cf_purge_zone_id:
             "ZONEID": _cf_purge_zone_id,
         },
     }
+
+WAGTAIL_ENABLE_UPDATE_CHECK = "lts"


### PR DESCRIPTION
Assuming we only want to keep up-to-date with long-term support versions of Wagtail, this configures the update warning to ignore non-LTS releases.

---
It's still asking for an upgrade from 5.2.1 to 5.2.4; we should put in place some mechanism to automate dependency updates, at least for security-related updates.