### PR TITLE
chore: Capture Nginx and Gunicorn logs in stdout

### DIFF
--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -1,6 +1,21 @@
+import json
+
 accesslog = "-"
 errorlog = "-"
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "%({X-Forwarded-For}i)s"'
+access_log_format = json.dumps(
+    {
+        "remote_host": "%(h)s",
+        "remote_logname": "%(l)s",
+        "remote_user": "%(u)s",
+        "timestamp": "%(t)s",
+        "request": "%(r)s",
+        "status_code": "%(s)s",
+        "response_size": "%(b)s",
+        "referrer": "%(f)s",
+        "user_agent": "%(a)s",
+        "x_forwarded_for": "%({x-forwarded-for}i)s",
+    }
+)
 capture_output = True
 forwarded_allow_ips = "*"
 secure_scheme_headers = {"X-CLOUDFRONT": "yes"}

--- a/docker/nginx-sandbox.conf
+++ b/docker/nginx-sandbox.conf
@@ -3,6 +3,8 @@ server {
     listen [::]:80 default_server;
     server_name _;
     gzip on;
+    access_log /dev/stdout;
+    error_log /dev/stdout warn;
     location / {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;

--- a/docker/supervisord-sandbox.conf
+++ b/docker/supervisord-sandbox.conf
@@ -3,9 +3,13 @@ nodaemon=true
 
 [program:nginx]
 command=nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:gunicorn]
 command=/usr/local/bin/gunicorn --config /app/docker/gunicorn.py ietf.wsgi
 directory=/app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
Fixes #432 and #433

I can see both Nginx and Gunicorn logs when I run `kubectl logs -f` locally now.

```text
127.0.0.1 - - [23/Apr/2024:04:23:57 +0100] "GET /healthz HTTP/1.0" 200 2 "-" "kube-probe/1.28" "10.244.0.1"
127.0.0.1 - - [23/Apr/2024:04:23:57 +0100] "GET /healthz HTTP/1.0" 200 2 "-" "kube-probe/1.28" "10.244.0.1"
10.244.0.1 - - [23/Apr/2024:03:23:57 +0000] "GET /healthz HTTP/1.1" 200 2 "-" "kube-probe/1.28"
10.244.0.1 - - [23/Apr/2024:03:23:57 +0000] "GET /healthz HTTP/1.1" 200 2 "-" "kube-probe/1.28"
127.0.0.1 - - [23/Apr/2024:04:24:06 +0100] "GET / HTTP/1.0" 200 30624 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0" "127.0.0.1"
127.0.0.1 - - [23/Apr/2024:03:24:06 +0000] "GET / HTTP/1.1" 200 5552 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0"
127.0.0.1 - - [23/Apr/2024:03:24:06 +0000] "GET /static/dist/main.9949552e4686.css HTTP/1.1" 200 324461 "http://localhost:8080/" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0"
127.0.0.1 - - [23/Apr/2024:03:24:06 +0000] "GET /static/img/youtube-icon.c20ebf0e90c8.svg HTTP/1.1" 200 930 "http://localhost:8080/" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0"
```

However, I'm not sure about the second commit. Configuring the Grafana agent to read from a file path may be cleaner (e.g. `/var/log/nginx/access.log`). To be discussed further.

Update: Fixing #433 in the same PR now.