### PR TITLE
chore: Use prod settings by default in Helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -210,7 +210,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 env:
-  DJANGO_SETTINGS_MODULE: "ietf.settings.dev"
+  DJANGO_SETTINGS_MODULE: "ietf.settings.production"
   EMAIL_HOST: "localhost"
   DBHOST: "host.minikube.internal"
   DBNAME: "www"


### PR DESCRIPTION
Fixes #436 