### PR TITLE
feat: Define cron jobs running mgmt commands in Helm chart

### DIFF
--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -1,0 +1,39 @@
+{{- range .Values.cronjob.crons }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .name | quote }}
+spec:
+  schedule: {{ .schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          volumes:
+            - name: settings-local-volume
+              configMap:
+                name: django-configmap
+          containers:
+          - name: {{ .name | quote }}
+            image: "{{ .image.repository }}:{{ default $.Chart.AppVersion .image.tag }}"
+            imagePullPolicy: {{ .image.pullPolicy }}
+            volumeMounts:
+            - name: settings-local-volume
+              mountPath: /app/ietf/settings/local.py
+              subPath: local.py
+              readOnly: true
+            {{- if $.Values.env }}
+            env:
+            - name: "POD_IP"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- range $key, $val := $.Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+            command: {{ .command | toJson }}
+{{- end }}

--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -7,8 +7,10 @@ metadata:
 spec:
   schedule: {{ .schedule | quote }}
   timeZone: {{ .timeZone | quote }}
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0 # No retries
       template:
         spec:
           restartPolicy: Never

--- a/helm/templates/cronjob.yaml
+++ b/helm/templates/cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ .name | quote }}
 spec:
   schedule: {{ .schedule | quote }}
+  timeZone: {{ .timeZone | quote }}
   jobTemplate:
     spec:
       template:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -206,7 +206,7 @@ memcached:
 cronjob:
   crons:
     - name: mgmt-hourly
-      schedule: "0 * * * *"
+      schedule: "0 * * * *" # "At minute 0."
       timeZone: "Etc/UTC"
       image:
         repository: "ghcr.io/ietf-tools/www"
@@ -214,7 +214,7 @@ cronjob:
         # tag: "v2.1.10"
       command: ["python", "/app/manage.py", "publish_scheduled"]
     - name: mgmt-weekly
-      schedule: "0 0 * * 0"
+      schedule: "30 0 * * 0" # "At 00:30 on Sunday."
       timeZone: "Etc/UTC"
       image:
         repository: "ghcr.io/ietf-tools/www"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -207,6 +207,7 @@ cronjob:
   crons:
     - name: mgmt-hourly
       schedule: "0 * * * *"
+      timeZone: "Etc/UTC"
       image:
         repository: "ghcr.io/ietf-tools/www"
         pullPolicy: IfNotPresent
@@ -214,6 +215,7 @@ cronjob:
       command: ["python", "/app/manage.py", "publish_scheduled"]
     - name: mgmt-weekly
       schedule: "0 0 * * 0"
+      timeZone: "Etc/UTC"
       image:
         repository: "ghcr.io/ietf-tools/www"
         pullPolicy: IfNotPresent

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,7 +24,7 @@ wagtail:
     repository: "ghcr.io/ietf-tools/www"
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    # tag: "v2.1.3"
+    # tag: "v2.1.10"
 
   imagePullSecrets: []
   nameOverride: ""
@@ -198,6 +198,27 @@ memcached:
   nodeSelector: {}
 
   affinity: {}
+
+# -------------------------------------------------------------
+# SCHEDULED JOBS
+# -------------------------------------------------------------
+
+cronjob:
+  crons:
+    - name: mgmt-hourly
+      schedule: "0 * * * *"
+      image:
+        repository: "ghcr.io/ietf-tools/www"
+        pullPolicy: IfNotPresent
+        # tag: "v2.1.10"
+      command: ["python", "/app/manage.py", "publish_scheduled"]
+    - name: mgmt-weekly
+      schedule: "0 0 * * 0"
+      image:
+        repository: "ghcr.io/ietf-tools/www"
+        pullPolicy: IfNotPresent
+        # tag: "v2.1.10"
+      command: ["python", "/app/manage.py", "update_index"]
 
 # -------------------------------------------------------------
 # COMMON


### PR DESCRIPTION
Fixes \#431.

-   Two cron jobs:

    The PR defines two cron jobs, one hourly the other weekly.

    <https://docs.wagtail.org/en/stable/reference/management_commands.html>

    -   `publish_scheduled`:

        > We recommend running this command once an hour.

    -   `update_index`:

        > It is recommended to run this command once a week

    With the current spec, the daily job runs every hour at minute 0, and the weekly job runs on Sunday at 00:30 UTC. Note that the weekly database maintenance window currently occurs on Saturdays UTC, and will no overlap with the weekly cron job.

-   Verifying `helm install` output:

    With `tag` set to the latest image tag, `v2.1.10`, `helm install www helm --dry-run` outputs as below.

    ``` yaml
    ...
    ---
    # Source: www/templates/cronjob.yaml
    apiVersion: batch/v1
    kind: CronJob
    metadata:
      name: "mgmt-hourly"
    spec:
      schedule: "0 * * * *"
      timeZone: "Etc/UTC"
      concurrencyPolicy: Forbid
      jobTemplate:
        spec:
          backoffLimit: 0 # No retries
          template:
            spec:
              restartPolicy: Never
              volumes:
                - name: settings-local-volume
                  configMap:
                    name: django-configmap
              containers:
              - name: "mgmt-hourly"
                image: "ghcr.io/ietf-tools/www:v2.1.10"
                imagePullPolicy: IfNotPresent
                ...
                command: ["python","/app/manage.py","publish_scheduled"]
    ---
    # Source: www/templates/cronjob.yaml
    apiVersion: batch/v1
    kind: CronJob
    metadata:
      name: "mgmt-weekly"
    spec:
      schedule: "30 0 * * 0"
      timeZone: "Etc/UTC"
      concurrencyPolicy: Forbid
      jobTemplate:
        spec:
          backoffLimit: 0 # No retries
          template:
            spec:
              restartPolicy: Never
              volumes:
                - name: settings-local-volume
                  configMap:
                    name: django-configmap
              containers:
              - name: "mgmt-weekly"
                image: "ghcr.io/ietf-tools/www:v2.1.10"
                imagePullPolicy: IfNotPresent
                ...
                command: ["python","/app/manage.py","update_index"]
    ```
