### PR TITLE
fix: Add title to social media links (#457)

### DIFF
--- a/ietf/context_processors.py
+++ b/ietf/context_processors.py
@@ -28,11 +28,11 @@ def secondary_menu(site):
 def social_menu(site):
     social = SocialMediaSettings.for_site(site)
     links = [
-        {"url": social.linkedin, "icon": "linkedin"},
-        {"url": social.twitter, "icon": "twitter"},
-        {"url": social.youtube, "icon": "youtube"},
-        {"url": social.mastodon, "icon": "mastodon"},
-        {"url": social.github, "icon": "github"},
+        {"url": social.linkedin, "icon": "linkedin", "title": "LinkedIn"},
+        {"url": social.twitter, "icon": "twitter", "title": "Twitter"},
+        {"url": social.youtube, "icon": "youtube", "title": "YouTube"},
+        {"url": social.mastodon, "icon": "mastodon", "title": "Mastodon"},
+        {"url": social.github, "icon": "github", "title": "GitHub"},
     ]
     return filter(itemgetter("url"), links)
 

--- a/ietf/templates/includes/footer.html
+++ b/ietf/templates/includes/footer.html
@@ -31,7 +31,7 @@
         <div class="d-lg-flex justify-content-between align-items-start lh-1">
             <div class="d-flex fs-4 my-5 my-lg-0 ms-n2 my-5 me-3">
                 {% for item in SOCIAL_MENU %}
-                    <a class="d-block text-light px-2" href="{{ item.url }}" rel="me">
+                    <a class="d-block text-light px-2" href="{{ item.url }}" rel="me" title="{{ item.title }}">
                         <i class="bi bi-{{ item.icon }}"></i>
                     </a>
                 {% endfor %}


### PR DESCRIPTION
Fixes #456

Tested on https://ws-social-icons.dev.ietf.org
Google Chrome Lighthouse Accessibility report is happy with social media links.