### PR TITLE
chore: Remove trailing /admin/ from WAGTAILADMIN_BASE_URL in secrets

### DIFF
--- a/k8s/iabweb/secrets.yaml
+++ b/k8s/iabweb/secrets.yaml
@@ -9,7 +9,7 @@ stringData:
     Kesara Rathnayake <kesara@staff.ietf.org>
 
   IABWWW_ALLOWED_HOSTS: ".iab.org"  # newline-separated list also allowed
-  WAGTAILADMIN_BASE_URL: "https://www.iab.org/admin/"
+  WAGTAILADMIN_BASE_URL: "https://www.iab.org"
 
   # Outgoing email details
   IABWWW_EMAIL_HOST: "iab.mr.ietf.org"


### PR DESCRIPTION
Fixes #490 