### PR TITLE
fix: home page cta container obscuring button click

### DIFF
--- a/ietf/home/styles/home.scss
+++ b/ietf/home/styles/home.scss
@@ -25,6 +25,7 @@
         font-size: 18em;
         overflow: hidden;
         color: rgba(255,255,255, 0.05);
+        pointer-events: none;
     }
 }
 


### PR DESCRIPTION
At certain screen sizes the homepage paper plane in the footer can appear over the button (in Chrome/Firefox), obscuring clicks, but this makes the paper plane image avoid clicks so that the user can interact with the button.

![Screenshot from 2024-12-02 09-10-39](https://github.com/user-attachments/assets/944b0bdc-68e0-43d6-968d-c97fe3c79cf5)
