### PR TITLE
chore: Tweak gunicorn config

### DIFF
--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -18,7 +18,6 @@ access_log_format = json.dumps(
 )
 capture_output = True
 forwarded_allow_ips = "*"
-secure_scheme_headers = {"X-CLOUDFRONT": "yes"}
 workers = 8
 worker_class = "gthread"
 bind = ":8000"

--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -18,8 +18,9 @@ access_log_format = json.dumps(
 )
 capture_output = True
 forwarded_allow_ips = "*"
+# setting workers + threads = 2 * number of cores
 workers = 4
-threads = 2
+threads = 4
 worker_class = "gthread"
 bind = ":8000"
 chdir = "/app"

--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -19,13 +19,7 @@ access_log_format = json.dumps(
 capture_output = True
 forwarded_allow_ips = "*"
 secure_scheme_headers = {"X-CLOUDFRONT": "yes"}
-workers = 2
+workers = 8
 worker_class = "gthread"
-worker_connections = 5
 bind = ":8000"
-keep_alive = 75
 chdir = "/app"
-
-# Obfuscate the Server header (to the md5sum of "Springload")
-import gunicorn
-gunicorn.SERVER_SOFTWARE = "04e96149a2f64d6135c82d199ab62122"

--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -18,7 +18,8 @@ access_log_format = json.dumps(
 )
 capture_output = True
 forwarded_allow_ips = "*"
-workers = 8
+workers = 4
+threads = 2
 worker_class = "gthread"
 bind = ":8000"
 chdir = "/app"


### PR DESCRIPTION
Number of worker connections is unset. Default is 1000.
Keep alive time out is unset. Default is 2.
Removed server obfuscation header.
Removed obsolete `X-CLOUDFRONT` setting.
This updates number of workers and threads to match the number of core.