### PR TITLE
chore(nginx): Try html and txt files for IDs and RFCs

### DIFF
--- a/k8s/ietfweb/nginx-default.conf
+++ b/k8s/ietfweb/nginx-default.conf
@@ -85,6 +85,7 @@ server {
         autoindex_exact_size off;
         autoindex_localtime on;
         charset utf-8;
+        try_files  $${keepempty}uri $${keepempty}uri.html $${keepempty}uri.txt $${keepempty}uri/;
 
         location ~* \.xml$ {
             add_header Content-Disposition 'attachment';
@@ -111,6 +112,7 @@ server {
         autoindex_exact_size off;
         autoindex_localtime on;
         charset utf-8;
+        try_files  $${keepempty}uri $${keepempty}uri.html $${keepempty}uri.txt $${keepempty}uri/;
 
         location ~* \.xml$ {
             add_header Content-Disposition 'attachment';


### PR DESCRIPTION
Try `.html` and `.txt` files if file extension is not provided.