### PR TITLE
fix: try additional extensions for minutes

### DIFF
--- a/k8s/ietfweb/nginx-default.conf
+++ b/k8s/ietfweb/nginx-default.conf
@@ -128,7 +128,7 @@ server {
         charset utf-8;
 
         location ~* /minutes/.+$ {
-            try_files  $${keepempty}uri $${keepempty}uri.html $${keepempty}uri.txt $${keepempty}uri/;
+            try_files  $${keepempty}uri $${keepempty}uri.html $${keepempty}uri.HTML $${keepempty}uri.htm $${keepempty}uri.txt $${keepempty}uri.TXT $${keepempty}uri.pdf $${keepempty}uri/ =404;
         }
 
         error_page 404 = @error_redirect;


### PR DESCRIPTION
Spurred by [this email thread](https://mailarchive.ietf.org/arch/browse/wgchairs/?gbt=1&index=96v-DDqnO7YBa86SybPb9iD0aLM), I had a look at the extensions that show up for various minutes files served from the filesystem. This PR adds the the ones that cause the observed breakage to the `try_files` directive in nginx.

There are other ways this could be fixed. This is low-hanging, though.

N.b. it also changes the response to a 404 instead of redirecting to the `$uri/` version and 404ing there. That's not required.